### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/qcharts.py
+++ b/qcharts.py
@@ -262,17 +262,17 @@ class ScatterChart(Chart):
 
     def _v_to_string(self, value):
         if isinstance(self.vaxis_step, float):
-            return '%.2f' % value
+            return '{0:.2f}'.format(value)
         if isinstance(self.vaxis_step, int):
-            return '%d' % value
-        return '%s' % value
+            return '{0:d}'.format(value)
+        return '{0!s}'.format(value)
 
     def _h_to_string(self, value):
         if isinstance(self.haxis_step, float):
-            return '%.2f' % value
+            return '{0:.2f}'.format(value)
         if isinstance(self.haxis_step, int):
-            return '%d' % value
-        return '%s' % value
+            return '{0:d}'.format(value)
+        return '{0!s}'.format(value)
 
     def setup_default_values(self):
         def _min_max_delta(col):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:maxdesp:PyQtCharts?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:maxdesp:PyQtCharts?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
